### PR TITLE
Conversational coach: bidirectional chat

### DIFF
--- a/backend/app/coach.py
+++ b/backend/app/coach.py
@@ -8,52 +8,61 @@ from dotenv import load_dotenv
 load_dotenv()
 
 SYSTEM_PROMPT = """\
-You are DeepSquare, a friendly chess coach. The player already sees Stockfish's \
-eval and top lines on screen — never repeat or list them.
+You are DeepSquare, a friendly chess coach. You have an interactive board that \
+the player is looking at alongside this conversation.
 
-Your job: explain the **why** behind the position in 3-4 sentences. Be concise.
+Your role:
+- Answer questions about the current position
+- Explain strategic and tactical ideas
+- Set up positions when the player asks to study something specific
+- Coach through endgames, openings, or tactical exercises
 
-- Why does one side stand better? (structure, activity, king safety, space)
-- What's the plan? Give a clear strategic direction, not just "play Nf3."
-- Any danger to watch for? Threats or traps the player might miss.
-
-Style rules:
-- Write clean, flowing prose. No bullet points, no numbered lists, no headers.
+Guidelines:
 - Do not use contractions (write "you are" not "you're", "do not" not "don't").
 - Speak directly: "you," "your opponent."
 - Use standard chess vocabulary. Always name the opening or variation \
 (e.g., Sicilian Najdorf, Queen's Gambit Declined, Italian Four Knights). \
 Name tactical and strategic patterns by their proper terms: fork, pin, skewer, \
 discovered attack, center fork trick, Greek gift sacrifice, back rank mate, \
-outpost, fianchetto, pawn break, passed pawn, backward pawn, minority attack, \
-etc. Players expect and learn from these terms.
+outpost, fianchetto, pawn break, passed pawn, backward pawn, minority attack, etc.
+- Keep responses concise (3-6 sentences unless the player asks for more detail).
 - No "engine suggests" or "Stockfish recommends."
 - Do not end with generic advice like "keep it simple" or "stay focused."
 
-Formatting rules:
+Formatting:
 - Wrap each individual chess move in curly braces: {Nxe5}, {d4}, {O-O}. \
 For sequences, wrap each move separately: {Nxe5} {Nxe5} {d4}. \
 Do NOT put multiple moves inside one pair of braces.
 - Wrap key strategic or tactical concepts in square brackets: [center fork trick], \
 [pin on the f-file], [backward pawn on d6].
-- Do NOT use markdown bold (**) or any other formatting.\
+- Do NOT use markdown bold (**) or any other formatting.
+
+Position requests:
+- If the player asks to see a specific position, opening, endgame, or exercise, \
+explain that you cannot set up positions yet, but you can describe the position \
+in detail and coach them through the ideas. Suggest they set up the position \
+manually using the FEN input if they have one.
+- Focus on what you CAN do: answer questions, explain concepts, and coach \
+through positions the player sets up themselves.\
 """
 
 
 @dataclass
 class EngineInput:
     eval: float
-    top_lines: list[dict]  # [{"moves": "e4 e5 ...", "eval": 0.3}, ...]
+    top_lines: list[dict]
 
 
-def _build_user_message(fen: str, engine: EngineInput, moves: list[str] | None = None) -> str:
-    lines_text = "\n".join(
-        f"  {i+1}. {line['moves']} (eval: {line['eval']:+.2f})"
-        for i, line in enumerate(engine.top_lines)
-    )
+@dataclass
+class ChatMessage:
+    role: str  # "user" or "assistant"
+    text: str
+
+
+def _build_context(fen: str, moves: list[str] | None, engine: EngineInput | None) -> str:
+    """Build the current board context injected into each request."""
     parts = []
     if moves:
-        # Format as "1.e4 e5 2.Nf3 Nc6 ..."
         move_strs = []
         for i, san in enumerate(moves):
             if i % 2 == 0:
@@ -61,42 +70,51 @@ def _build_user_message(fen: str, engine: EngineInput, moves: list[str] | None =
             else:
                 move_strs.append(san)
         parts.append(f"Game so far: {' '.join(move_strs)}")
-    parts.append(f"Position (FEN): {fen}")
-    parts.append(f"Eval: {engine.eval:+.2f} (from white's perspective)")
-    parts.append(f"Top engine lines:\n{lines_text}")
+    parts.append(f"Current position (FEN): {fen}")
+    if engine:
+        lines_text = "\n".join(
+            f"  {i+1}. {line['moves']} (eval: {line['eval']:+.2f})"
+            for i, line in enumerate(engine.top_lines)
+        )
+        parts.append(f"Eval: {engine.eval:+.2f} (from white's perspective)")
+        parts.append(f"Top engine lines:\n{lines_text}")
     return "\n".join(parts)
 
 
 def _resolve_model(model: str | None) -> str:
-    """Resolve LLM model: request param > env var > default."""
     return model or os.environ.get("LLM_MODEL", "claude-haiku-4-5-20251001")
 
 
 def _resolve_api_key(api_key: str | None) -> str | None:
-    """Resolve API key: request param > env var."""
     return api_key or os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY")
 
 
-def stream_coaching(
+def stream_chat(
+    messages: list[ChatMessage],
     fen: str,
-    engine: EngineInput,
     moves: list[str] | None = None,
+    engine: EngineInput | None = None,
     api_key: str | None = None,
     model: str | None = None,
 ) -> Generator[str, None, None]:
-    """Stream coaching response token by token."""
+    """Stream a chat response token by token."""
     resolved_model = _resolve_model(model)
     resolved_key = _resolve_api_key(api_key)
 
     if not resolved_key:
         raise ValueError("No API key provided. Set your key in Settings or in the server .env file.")
 
+    # Build messages for litellm
+    context = _build_context(fen, moves, engine)
+    system_msg = SYSTEM_PROMPT + f"\n\n--- Current Board State ---\n{context}"
+
+    llm_messages = [{"role": "system", "content": system_msg}]
+    for msg in messages:
+        llm_messages.append({"role": msg.role, "content": msg.text})
+
     response = litellm.completion(
         model=resolved_model,
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": _build_user_message(fen, engine, moves)},
-        ],
+        messages=llm_messages,
         max_tokens=500,
         temperature=0.7,
         stream=True,

--- a/backend/app/engine.py
+++ b/backend/app/engine.py
@@ -35,12 +35,28 @@ def stop() -> None:
         _engine = None
 
 
-def analyze(fen: str, time_limit: float = 1.0, num_lines: int = 3) -> AnalysisResult:
+def _ensure_running() -> chess.engine.SimpleEngine:
+    """Return the engine, restarting it if it crashed."""
+    global _engine
     if _engine is None:
         raise RuntimeError("Engine not started — call engine.start() first")
+    try:
+        # Ping the engine to check if it's alive
+        _engine.ping()
+    except chess.engine.EngineTerminatedError:
+        # Engine crashed — restart it
+        _engine = None
+        start()
+        if _engine is None:
+            raise RuntimeError("Failed to restart engine")
+    return _engine
+
+
+def analyze(fen: str, time_limit: float = 1.0, num_lines: int = 3) -> AnalysisResult:
+    eng = _ensure_running()
 
     board = chess.Board(fen)
-    infos = _engine.analyse(board, chess.engine.Limit(time=time_limit), multipv=num_lines)
+    infos = eng.analyse(board, chess.engine.Limit(time=time_limit), multipv=num_lines)
 
     lines: list[Line] = []
     for info in infos:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 from app import engine
-from app.coach import EngineInput, stream_coaching
+from app.coach import ChatMessage, EngineInput, stream_chat
 
 
 @asynccontextmanager
@@ -46,11 +46,17 @@ class AnalyzeResponse(BaseModel):
     top_lines: list[EngineLine]
 
 
-class CoachRequest(BaseModel):
+class ChatMessageIn(BaseModel):
+    role: str
+    text: str
+
+
+class ChatRequest(BaseModel):
+    messages: list[ChatMessageIn]
     fen: str
-    engine_eval: float
-    top_lines: list[EngineLine]
-    moves: list[str] = []  # SAN move history leading to this position
+    moves: list[str] = []
+    engine_eval: float | None = None
+    top_lines: list[EngineLine] | None = None
 
 
 # ── Endpoints ──
@@ -63,7 +69,7 @@ def health():
 @app.post("/analyze", response_model=AnalyzeResponse)
 def analyze(req: AnalyzeRequest):
     try:
-        chess.Board(req.fen)  # validate FEN
+        chess.Board(req.fen)
     except ValueError:
         return JSONResponse(status_code=422, content={"error": "Invalid FEN string."})
 
@@ -78,21 +84,32 @@ def analyze(req: AnalyzeRequest):
     )
 
 
-@app.post("/coach")
-async def coach(req: CoachRequest, request: Request):
-    """SSE endpoint: accepts engine data + API key from frontend, streams coaching."""
+@app.post("/chat")
+async def chat(req: ChatRequest, request: Request):
+    """SSE endpoint: conversational coach with board control."""
     api_key = request.headers.get("x-api-key")
     model = request.headers.get("x-llm-model")
 
-    engine_input = EngineInput(
-        eval=req.engine_eval,
-        top_lines=[{"moves": l.moves, "eval": l.eval} for l in req.top_lines],
-    )
+    engine_input = None
+    if req.engine_eval is not None and req.top_lines is not None:
+        engine_input = EngineInput(
+            eval=req.engine_eval,
+            top_lines=[{"moves": l.moves, "eval": l.eval} for l in req.top_lines],
+        )
+
+    messages = [ChatMessage(role=m.role, text=m.text) for m in req.messages]
 
     def event_generator():
         try:
-            for token in stream_coaching(req.fen, engine_input, moves=req.moves, api_key=api_key, model=model):
-                yield {"event": "coaching", "data": token}
+            for token in stream_chat(
+                messages=messages,
+                fen=req.fen,
+                moves=req.moves,
+                engine=engine_input,
+                api_key=api_key,
+                model=model,
+            ):
+                yield {"event": "token", "data": token}
             yield {"event": "done", "data": ""}
         except ValueError as e:
             yield {"event": "error", "data": str(e)}
@@ -105,6 +122,6 @@ async def coach(req: CoachRequest, request: Request):
             elif "balance" in msg.lower() or "credit" in msg.lower():
                 yield {"event": "error", "data": "Insufficient API credits. Add credits to your account."}
             else:
-                yield {"event": "error", "data": f"Coaching error: {msg}"}
+                yield {"event": "error", "data": f"Chat error: {msg}"}
 
     return EventSourceResponse(event_generator())

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -258,21 +258,26 @@ main {
   margin-bottom: 8px;
 }
 
-/* ── Coaching section ── */
-.coaching-section {
+/* ── Chat section ── */
+.chat-section {
   background: var(--bg-surface);
   border-radius: 8px;
-  padding: 16px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+  max-height: 400px;
 }
 
-.coaching-header {
+.chat-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 8px;
+  padding: 0 4px;
 }
 
-.coaching-header h3 {
+.chat-header h3 {
   margin-bottom: 0;
 }
 
@@ -298,10 +303,100 @@ main {
   cursor: not-allowed;
 }
 
-.coaching-body p {
-  line-height: 1.65;
-  font-size: 15px;
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding: 4px;
+}
+
+.chat-empty {
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+  padding: 24px 8px;
+}
+
+.chat-msg p {
+  line-height: 1.6;
+  font-size: 14px;
+  margin: 0;
+}
+
+.chat-user {
+  align-self: flex-end;
+  background: var(--accent);
   color: var(--text);
+  padding: 8px 12px;
+  border-radius: 12px 12px 2px 12px;
+  max-width: 85%;
+}
+
+.chat-assistant {
+  align-self: flex-start;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 8px 12px;
+  border-radius: 12px 12px 12px 2px;
+  max-width: 85%;
+}
+
+.chat-fen-set {
+  font-size: 11px;
+  color: #52b788;
+  margin-top: 4px;
+  font-weight: 600;
+}
+
+.chat-input-form {
+  display: flex;
+  gap: 6px;
+}
+
+.chat-input {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+}
+
+.chat-input:focus {
+  outline: none;
+  border-color: var(--accent-bright);
+}
+
+.chat-input:disabled {
+  opacity: 0.5;
+}
+
+.btn-send {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+
+.btn-send:hover:not(:disabled) {
+  background: var(--accent);
+}
+
+.btn-send:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 code.move {
@@ -312,15 +407,6 @@ code.move {
   color: var(--accent-bright);
   padding: 1px 5px;
   border-radius: 3px;
-}
-
-.coaching-body p.placeholder {
-  color: var(--text-muted);
-  font-size: 14px;
-}
-
-.coaching-body p.is-stale {
-  opacity: 0.5;
 }
 
 /* ── Engine lines ── */
@@ -611,7 +697,12 @@ code.move {
     max-width: 480px;
   }
 
-  .coaching-body p {
-    font-size: 14px;
+  .chat-section {
+    max-height: 300px;
+    min-height: 150px;
+  }
+
+  .chat-msg p {
+    font-size: 13px;
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,43 +10,40 @@ import 'chessground/assets/chessground.cburnett.css'
 import './App.css'
 
 const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+// Match [FEN: ...] or bare "FEN: ..." on its own line
+// Reserved for future position database feature
+// const FEN_MARKER_RE = /\[FEN:\s*([^\]]+)\]/
 
 // ── Helpers ──
 
-// Chess move pattern: standard algebraic notation
-// Matches: e4, Nf3, Bxe5, O-O, O-O-O, Qxf7+, Rh8#, exd5, Nbd2, R1e1
 const MOVE_RE = /(?<![a-zA-Z])([KQRBN][a-h]?[1-8]?x?[a-h][1-8](?:=[QRBN])?[+#]?|[a-h]x[a-h][1-8](?:=[QRBN])?[+#]?|[a-h][1-8][+#]?|O-O(?:-O)?[+#]?)(?![a-zA-Z])/g
 
-function cleanCoaching(raw: string): string {
+function formatCoachText(raw: string): string {
   let text = raw
-  // Fix tokenizer splitting contractions: "You 're" → "You're"
+  // Strip FEN markers from display text
+  text = text.replace(/\[FEN:\s*[^\]]+\]/g, '').replace(/(?:^|\n)FEN:\s*.+/g, '').trim()
+  // Fix tokenizer artifacts
   text = text.replace(/ '/g, "'")
-  // Fix spaces before punctuation: "coordination ." → "coordination."
   text = text.replace(/ ([.,;:!?])/g, '$1')
-
-  // Process explicit {move} markers: strip spaces inside
+  // Process {move} markers
   text = text.replace(/\{([^}]*)\}/g, (_, inner: string) => {
     const clean = inner.replace(/\s+/g, '')
     return `<code class="move">${clean}</code>`
   })
-  // Process [concept] markers
-  text = text.replace(/\[([^\]]*)\]/g, (_, inner) => {
+  // Process [concept] markers (but not [FEN:...])
+  text = text.replace(/\[(?!FEN:)([^\]]*)\]/g, (_, inner) => {
     const clean = inner.replace(/\s+/g, ' ').trim()
     return `<strong>${clean}</strong>`
   })
   // Clean up stray **
   text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
   text = text.replace(/\*\*/g, '')
-
-  // Auto-detect unwrapped chess moves — run on the current text
-  // but skip content already inside <code> tags.
-  // Split by <code>...</code> segments, only process outside segments.
+  // Auto-detect unwrapped chess moves
   const parts = text.split(/(<code class="move">.*?<\/code>)/g)
   text = parts.map(part => {
     if (part.startsWith('<code class="move">')) return part
     return part.replace(MOVE_RE, (match) => `<code class="move">${match}</code>`)
   }).join('')
-
   return text
 }
 
@@ -77,6 +74,11 @@ interface HistoryEntry {
   san?: string
 }
 
+interface ChatMsg {
+  role: 'user' | 'assistant'
+  text: string
+}
+
 // ── Components ──
 
 function MoveList({ history, currentIndex, onJump }: {
@@ -84,7 +86,7 @@ function MoveList({ history, currentIndex, onJump }: {
   currentIndex: number
   onJump: (index: number) => void
 }) {
-  const moves = history.slice(1) // skip starting position
+  const moves = history.slice(1)
   if (moves.length === 0) return null
 
   const pairs: { num: number; white: { san: string; idx: number }; black?: { san: string; idx: number } }[] = []
@@ -120,6 +122,44 @@ function MoveList({ history, currentIndex, onJump }: {
   )
 }
 
+function ChatMessages({ messages, streaming }: { messages: ChatMsg[]; streaming: string }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [messages, streaming])
+
+  const hasContent = messages.length > 0 || streaming
+
+  return (
+    <div className="chat-messages" ref={scrollRef}>
+      {!hasContent && (
+        <div className="chat-empty">
+          Ask about the position, request a scenario, or click "Coach me" to get started.
+        </div>
+      )}
+      {messages.map((msg, i) => (
+        <div key={i} className={`chat-msg chat-${msg.role}`}>
+          {msg.role === 'user' ? (
+            <p>{msg.text}</p>
+          ) : (
+            <>
+              <p dangerouslySetInnerHTML={{ __html: formatCoachText(msg.text) }} />
+            </>
+          )}
+        </div>
+      ))}
+      {streaming && (
+        <div className="chat-msg chat-assistant">
+          <p dangerouslySetInnerHTML={{ __html: formatCoachText(streaming) }} />
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── App ──
 
 function App() {
@@ -130,8 +170,6 @@ function App() {
   // History
   const [history, setHistory] = useState<HistoryEntry[]>([{ fen: START_FEN }])
   const [currentIndex, setCurrentIndex] = useState(0)
-
-  // Derived FEN from history
   const currentFen = history[currentIndex].fen
   const atLatest = currentIndex === history.length - 1
 
@@ -139,16 +177,20 @@ function App() {
   const [settings, setSettings] = useState<LLMSettings>(loadSettings)
   const [settingsOpen, setSettingsOpen] = useState(false)
 
-  // Engine / coaching
+  // Engine
   const [engineData, setEngineData] = useState<EngineData | null>(null)
-  const [coaching, setCoaching] = useState('')
   const [engineError, setEngineError] = useState('')
-  const [coachError, setCoachError] = useState('')
   const [analyzing, setAnalyzing] = useState(false)
   const [engineLoading, setEngineLoading] = useState(false)
-  const [coachLoading, setCoachLoading] = useState(false)
   const engineAbortRef = useRef<AbortController | null>(null)
-  const coachAbortRef = useRef<AbortController | null>(null)
+
+  // Chat
+  const [chatMessages, setChatMessages] = useState<ChatMsg[]>([])
+  const [streaming, setStreaming] = useState('')
+  const [chatLoading, setChatLoading] = useState(false)
+  const [chatError, setChatError] = useState('')
+  const [chatInput, setChatInput] = useState('')
+  const chatAbortRef = useRef<AbortController | null>(null)
 
   const evalValue = engineData?.eval ?? 0
   const evalClamped = Math.max(-5, Math.min(5, evalValue))
@@ -173,6 +215,7 @@ function App() {
       },
     })
   }, [])
+
 
   // ── Fetchers ──
 
@@ -206,36 +249,54 @@ function App() {
   const settingsRef = useRef(settings)
   settingsRef.current = settings
 
-  const fetchCoaching = useCallback(async (fen: string, engine: EngineData, moves: string[] = []) => {
+  const sendChat = useCallback(async (userText: string) => {
     const s = settingsRef.current
     if (!s.apiKey) {
-      setCoachError('Set your API key in Settings to use the coach.')
+      setChatError('Set your API key in Settings to use the coach.')
       return
     }
-    coachAbortRef.current?.abort()
+
+    const userMsg: ChatMsg = { role: 'user', text: userText }
+    setChatMessages(prev => [...prev, userMsg])
+    setChatInput('')
+
+    chatAbortRef.current?.abort()
     const controller = new AbortController()
-    coachAbortRef.current = controller
-    setCoachLoading(true)
-    setCoaching('')
-    setCoachError('')
+    chatAbortRef.current = controller
+    setChatLoading(true)
+    setStreaming('')
+    setChatError('')
+
+    // Build message history for API
+    const allMessages = [...chatMessages, userMsg]
+    const moves = history.slice(1, currentIndex + 1).map(h => h.san).filter(Boolean) as string[]
+
     try {
-      const res = await fetch('/api/coach', {
+      const res = await fetch('/api/chat', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-API-Key': s.apiKey,
           'X-LLM-Model': s.model,
         },
-        body: JSON.stringify({ fen, engine_eval: engine.eval, top_lines: engine.top_lines, moves }),
+        body: JSON.stringify({
+          messages: allMessages.map(m => ({ role: m.role, text: m.text })),
+          fen: currentFen,
+          moves,
+          engine_eval: engineData?.eval ?? null,
+          top_lines: engineData?.top_lines ?? null,
+        }),
         signal: controller.signal,
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
+
       const reader = res.body?.getReader()
       if (!reader) throw new Error('No response body')
       const decoder = new TextDecoder()
       let buffer = ''
-      let coachingText = ''
+      let fullText = ''
       let currentEvent = ''
+
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
@@ -247,22 +308,34 @@ function App() {
             currentEvent = line.slice(6).trim()
           } else if (line.startsWith('data:')) {
             const data = line.startsWith('data: ') ? line.slice(6) : line.slice(5)
-            if (currentEvent === 'coaching') {
-              coachingText += data
-              setCoaching(coachingText)
+            if (currentEvent === 'token') {
+              fullText += data
+              setStreaming(fullText)
             } else if (currentEvent === 'error') {
-              setCoachError(data)
+              setChatError(data)
             }
           }
         }
       }
+
+      // Streaming done — finalize message
+      if (fullText) {
+        // Check for FEN marker
+        const assistantMsg: ChatMsg = {
+          role: 'assistant',
+          text: fullText,
+        }
+        setChatMessages(prev => [...prev, assistantMsg])
+        setStreaming('')
+      }
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return
-      setCoachError(err instanceof Error ? err.message : 'Coaching request failed.')
+      setChatError(err instanceof Error ? err.message : 'Chat request failed.')
     } finally {
-      setCoachLoading(false)
+      setChatLoading(false)
+      setStreaming('')
     }
-  }, [])
+  }, [chatMessages, currentFen, engineData, history, currentIndex])
 
   // ── Auto-analyze on position change ──
 
@@ -296,12 +369,7 @@ function App() {
                 lastMove: [orig, dest],
                 san: move.san,
               }
-              setHistory(prev => {
-                // Get current index from prev length context — we always
-                // append at the latest when making a move
-                const sliced = prev.slice(0, prev.length)
-                return [...sliced, newEntry]
-              })
+              setHistory(prev => [...prev.slice(0, prev.length), newEntry])
               setCurrentIndex(prev => prev + 1)
               cgRef.current?.set({
                 turnColor: turnColor(chess),
@@ -334,40 +402,23 @@ function App() {
   const goForward = useCallback(() => navigateTo(currentIndex + 1), [navigateTo, currentIndex])
   const goEnd = useCallback(() => navigateTo(history.length - 1), [navigateTo, history.length])
 
-  // When a move is made while viewing a past position, we need to handle it:
-  // The move handler always appends. But if we're viewing a past position,
-  // we need to truncate forward history first and jump to the end.
-  // We do this by jumping to the end before allowing moves.
-  // When currentIndex changes and we're not at latest, disable moves.
   useEffect(() => {
     if (!cgRef.current) return
     if (atLatest) {
       const chess = chessRef.current
       cgRef.current.set({
-        movable: {
-          color: turnColor(chess),
-          dests: toDests(chess),
-        },
+        movable: { color: turnColor(chess), dests: toDests(chess) },
       })
     } else {
       cgRef.current.set({
-        movable: {
-          color: undefined,
-          dests: undefined,
-        },
+        movable: { color: undefined, dests: undefined },
       })
     }
   }, [atLatest])
 
-  // Handle making a move when not at latest: jump to end first, truncate
-  // Actually, simpler: only allow moves at latest position (handled above)
-  // If user wants to play from a past position, they need to go to end first.
-  // TODO: Could truncate and allow, but for now this matches Lichess behavior.
-
-  // Keyboard navigation
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement) return
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
       if (e.key === 'ArrowLeft') { e.preventDefault(); goBack() }
       else if (e.key === 'ArrowRight') { e.preventDefault(); goForward() }
     }
@@ -385,32 +436,34 @@ function App() {
       setHistory([entry])
       setCurrentIndex(0)
       showPosition(entry, true)
-    } catch {
-      // invalid FEN
-    }
+    } catch { /* invalid FEN */ }
   }
 
   const handleToggleAnalysis = () => {
     if (analyzing) {
       engineAbortRef.current?.abort()
-      coachAbortRef.current?.abort()
+      chatAbortRef.current?.abort()
       setAnalyzing(false)
       setEngineLoading(false)
-      setCoachLoading(false)
+      setChatLoading(false)
       setEngineData(null)
-      setCoaching('')
       setEngineError('')
-      setCoachError('')
+      setChatError('')
+      setChatMessages([])
+      setStreaming('')
     } else {
       setAnalyzing(true)
     }
   }
 
   const handleCoachMe = () => {
-    if (!engineData) return
-    // Build move list from history up to current position
-    const moves = history.slice(1, currentIndex + 1).map(h => h.san).filter(Boolean) as string[]
-    fetchCoaching(currentFen, engineData, moves)
+    sendChat('Analyze this position and coach me.')
+  }
+
+  const handleChatSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!chatInput.trim() || chatLoading) return
+    sendChat(chatInput.trim())
   }
 
   const handleReset = () => {
@@ -419,9 +472,10 @@ function App() {
     setHistory([{ fen: START_FEN }])
     setCurrentIndex(0)
     setEngineData(null)
-    setCoaching('')
     setEngineError('')
-    setCoachError('')
+    setChatMessages([])
+    setStreaming('')
+    setChatError('')
     showPosition({ fen: START_FEN }, true)
   }
 
@@ -480,37 +534,43 @@ function App() {
         <div className="side-panel">
           <MoveList history={history} currentIndex={currentIndex} onJump={navigateTo} />
 
-          <section className="coaching-section">
-            <div className="coaching-header">
-              <h3>Coach {coachLoading && <span className="loading-dot" />}</h3>
+          <section className="chat-section">
+            <div className="chat-header">
+              <h3>Coach {chatLoading && <span className="loading-dot" />}</h3>
               {analyzing && (
                 <button
                   className="btn-coach"
                   onClick={handleCoachMe}
-                  disabled={coachLoading || !hasKey || !hasEngine}
+                  disabled={chatLoading || !hasKey || !hasEngine}
                   title={!hasKey ? 'Set your API key in Settings' : undefined}
                 >
-                  {coachLoading ? 'Thinking...' : 'Coach me'}
+                  {chatLoading ? 'Thinking...' : 'Coach me'}
                 </button>
               )}
             </div>
-            <div className="coaching-body">
-              {coachError ? (
-                <p className="error-msg">{coachError}</p>
-              ) : coaching ? (
-                <p dangerouslySetInnerHTML={{
-                  __html: cleanCoaching(coaching)
-                }} />
-              ) : (
-                <p className="placeholder">
-                  {!hasKey
-                    ? 'Set your API key in ⚙ Settings to use the coach.'
-                    : analyzing
-                      ? 'Click "Coach me" for position advice.'
-                      : 'Click Analyze to start engine analysis.'}
-                </p>
-              )}
-            </div>
+
+            <ChatMessages messages={chatMessages} streaming={streaming} />
+
+            {chatError && <div className="error-msg">{chatError}</div>}
+
+            <form className="chat-input-form" onSubmit={handleChatSubmit}>
+              <input
+                type="text"
+                className="chat-input"
+                value={chatInput}
+                onChange={e => setChatInput(e.target.value)}
+                placeholder={hasKey ? 'Ask about this position...' : 'Set API key in ⚙ Settings'}
+                disabled={!hasKey || chatLoading}
+                spellCheck={false}
+              />
+              <button
+                type="submit"
+                className="btn-send"
+                disabled={!hasKey || chatLoading || !chatInput.trim()}
+              >
+                ↑
+              </button>
+            </form>
           </section>
 
           <section className="engine-section">


### PR DESCRIPTION
## Summary
- Replaces one-way "Coach me" with a full chat interface
- Users can ask questions about the current position, get follow-ups, and have a back-and-forth dialogue
- Conversation history maintained and sent with each request for context
- Stockfish auto-restarts if the engine process crashes
- Removed unreliable LLM FEN generation (filed #6 for curated position database)

## What changed
- **Backend**: New `/chat` endpoint replaces `/coach`, accepts conversation history
- **Frontend**: Chat message bubbles, text input, scrollable message area
- **Engine**: Auto-restart on crash via `_ensure_running()` ping check

## Test plan
- [ ] Click Analyze → Coach me → streams first response
- [ ] Type a question → gets contextual response about current position
- [ ] Ask follow-up → LLM has conversation history
- [ ] Ask to show a position → coach explains it can't set positions yet
- [ ] Make moves while chatting → new analysis reflects new position
- [ ] Stop → clears chat and analysis
- [ ] Mobile: chat scrolls, input works

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)