### PR TITLE
Structured piece-list generation for custom positions

### DIFF
--- a/backend/app/coach.py
+++ b/backend/app/coach.py
@@ -51,8 +51,8 @@ king and pawn, bishop and knight mate, etc.), tactics/puzzles (fork, pin, \
 skewer, back rank mate, smothered mate, etc.), famous games (morphy opera game, \
 kasparov topalov, fischer byrne, evergreen, etc.).
 
-**Option 2: Build a custom position (for anything not in the database)**
-For custom or unusual positions, output a JSON piece list:
+**Option 2: Build a custom position (ONLY if Option 1 cannot work)**
+For truly custom positions that could not possibly be in any database, output a JSON piece list:
 [SETUP: {"side_to_move": "white", "pieces": [{"color": "white", "type": "K", "square": "e1"}, {"color": "black", "type": "K", "square": "e8"}, {"color": "white", "type": "R", "square": "a1"}]}]
 Rules for SETUP:
 - type must be one of: K, Q, R, B, N, P

--- a/backend/app/coach.py
+++ b/backend/app/coach.py
@@ -38,21 +38,31 @@ Do NOT put multiple moves inside one pair of braces.
 - Do NOT use markdown bold (**) or any other formatting.
 
 Position requests:
-- When the player asks to see a specific position, opening, endgame, puzzle, \
-or exercise, include a search marker on the LAST line of your response:
+You have TWO ways to set up positions on the board. Use the first whenever possible.
+
+**Option 1: Search the database (preferred for known positions)**
+For well-known openings, endgames, puzzles, or famous games, use a search marker:
 [POSITION: lucena rook endgame]
 [POSITION: caro-kann advance variation]
 [POSITION: fork puzzle]
-- The app will search a database and set the board automatically.
-- Write a brief introduction about the position BEFORE the marker.
-- The search query should be descriptive keywords (opening name, endgame type, \
-tactical theme, or famous game name).
-- Available categories: openings (sicilian, caro-kann, french, ruy lopez, etc.), \
-endgames (lucena, philidor, vancura, king and pawn, etc.), \
-tactics/puzzles (fork, pin, skewer, back rank mate, etc.), \
-famous games (morphy opera game, kasparov topalov, fischer byrne, etc.).
-- If you are not sure a position exists in the database, still include the marker — \
-the app will handle "not found" gracefully.\
+Available: openings (sicilian, caro-kann, french, ruy lopez, italian, london, \
+kings indian, queens gambit, etc.), endgames (lucena, philidor, vancura, \
+king and pawn, bishop and knight mate, etc.), tactics/puzzles (fork, pin, \
+skewer, back rank mate, smothered mate, etc.), famous games (morphy opera game, \
+kasparov topalov, fischer byrne, evergreen, etc.).
+
+**Option 2: Build a custom position (for anything not in the database)**
+For custom or unusual positions, output a JSON piece list:
+[SETUP: {"side_to_move": "white", "pieces": [{"color": "white", "type": "K", "square": "e1"}, {"color": "black", "type": "K", "square": "e8"}, {"color": "white", "type": "R", "square": "a1"}]}]
+Rules for SETUP:
+- type must be one of: K, Q, R, B, N, P
+- square must be like "e4" (file a-h, rank 1-8)
+- Each side MUST have exactly one King
+- No pawns on ranks 1 or 8
+- Kings cannot be on adjacent squares
+- List EVERY piece on the board — empty squares are implied
+
+For BOTH options: write the marker on the LAST line. Describe the position first.\
 """
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from app import engine, positions
 from app.coach import ChatMessage, EngineInput, stream_chat
+from app.positions import validate_and_convert_setup
 
 
 @asynccontextmanager
@@ -74,6 +75,15 @@ async def search_positions(q: str):
         {"name": r.name, "description": r.description, "fen": r.fen, "source": r.source}
         for r in results
     ]
+
+
+@app.post("/positions/setup")
+def setup_position(data: dict):
+    """Validate a structured piece list and convert to FEN."""
+    fen, error = validate_and_convert_setup(data)
+    if error:
+        return JSONResponse(status_code=422, content={"error": error})
+    return {"fen": fen}
 
 
 @app.post("/analyze", response_model=AnalyzeResponse)

--- a/backend/app/positions.json
+++ b/backend/app/positions.json
@@ -166,5 +166,23 @@
     "tags": ["famous game", "anderssen", "evergreen", "romantic chess", "sacrifice"],
     "description": "Adolf Anderssen's brilliant attack with multiple sacrifices — a jewel of romantic chess",
     "fen": "r1b2rk1/pppp1ppp/8/4P3/1n2P1nq/2N2N2/PPP1BKPP/R1BQ3R w - - 0 1"
+  },
+  {
+    "name": "Bishop and Pawns Endgame (Good vs Bad Bishop)",
+    "tags": ["bishop endgame", "endgame", "pawn endgame", "good bishop", "bad bishop"],
+    "description": "White's bishop is active on the long diagonal while Black's bishop is blocked by its own pawns — a classic good vs bad bishop endgame",
+    "fen": "8/pp3pp1/2p1b2p/3p4/3P1B2/2P2P1P/PP3PP1/4K2k w - - 0 1"
+  },
+  {
+    "name": "Opposite-Colored Bishops Endgame",
+    "tags": ["bishop endgame", "endgame", "opposite colored bishops", "drawing"],
+    "description": "Opposite-colored bishops often lead to draws even with extra pawns — the defender's bishop controls the promotion squares",
+    "fen": "8/3k1pp1/p2b4/1p1P4/1P6/P4B2/5PP1/6K1 w - - 0 1"
+  },
+  {
+    "name": "Wrong-Colored Bishop and Rook Pawn",
+    "tags": ["bishop endgame", "endgame", "rook pawn", "wrong bishop", "drawing"],
+    "description": "A famous drawing pattern — the bishop cannot control the promotion square of a rook pawn, so the defender's king reaches the corner",
+    "fen": "7k/8/6KP/8/2B5/8/8/8 w - - 0 1"
   }
 ]

--- a/backend/app/positions.py
+++ b/backend/app/positions.py
@@ -37,24 +37,36 @@ def _load_db() -> list[dict]:
 def _score_match(entry: dict, query: str) -> int:
     """Score how well an entry matches the query. Higher is better."""
     q = query.lower()
-    words = q.split()
-    score = 0
+    words = [w for w in q.split() if len(w) > 2]  # skip short words like "a", "vs"
+    if not words:
+        return 0
 
     name_lower = entry["name"].lower()
-    tags_lower = " ".join(entry.get("tags", [])).lower()
+    tags = [t.lower() for t in entry.get("tags", [])]
+    tags_str = " ".join(tags)
     desc_lower = entry.get("description", "").lower()
 
-    # Exact name match
+    score = 0
+
+    # Full query match in name
     if q in name_lower:
         score += 100
-    # Word matches in name (highest weight)
-    for w in words:
-        if w in name_lower:
-            score += 20
-        if w in tags_lower:
-            score += 10
-        if w in desc_lower:
-            score += 3
+
+    # Full tag match (e.g., "rook endgame" matches tag "rook endgame")
+    for tag in tags:
+        if tag in q or q in tag:
+            score += 30
+
+    # Word matches — count how many query words match
+    name_hits = sum(1 for w in words if w in name_lower)
+    tag_hits = sum(1 for w in words if w in tags_str)
+    desc_hits = sum(1 for w in words if w in desc_lower)
+
+    # Reward proportional matching — more matched words = much higher score
+    match_ratio = (name_hits + tag_hits) / len(words) if words else 0
+    score += int(name_hits * 15 * match_ratio)
+    score += int(tag_hits * 8 * match_ratio)
+    score += desc_hits * 2
 
     return score
 
@@ -63,7 +75,7 @@ def search_curated(query: str, limit: int = 3) -> list[PositionResult]:
     """Search the curated position database."""
     db = _load_db()
     scored = [(entry, _score_match(entry, query)) for entry in db]
-    scored = [(e, s) for e, s in scored if s > 0]
+    scored = [(e, s) for e, s in scored if s >= 10]
     scored.sort(key=lambda x: x[1], reverse=True)
 
     return [

--- a/backend/app/positions.py
+++ b/backend/app/positions.py
@@ -2,6 +2,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+import chess
 import httpx
 
 _DB: list[dict] = []
@@ -130,7 +131,6 @@ async def search_lichess_puzzle(query: str) -> PositionResult | None:
                 return None
 
             # Replay PGN to get the puzzle starting position
-            import chess
             board = chess.Board()
             for san in pgn.split():
                 try:
@@ -147,6 +147,94 @@ async def search_lichess_puzzle(query: str) -> PositionResult | None:
             )
     except Exception:
         return None
+
+
+PIECE_MAP = {
+    "K": chess.KING, "Q": chess.QUEEN, "R": chess.ROOK,
+    "B": chess.BISHOP, "N": chess.KNIGHT, "P": chess.PAWN,
+}
+
+COLOR_MAP = {"white": chess.WHITE, "black": chess.BLACK}
+
+
+def validate_and_convert_setup(data: dict) -> tuple[str | None, str | None]:
+    """Validate a structured piece list and convert to FEN.
+    Returns (fen, None) on success or (None, error_message) on failure."""
+    pieces = data.get("pieces", [])
+    side_to_move = data.get("side_to_move", "white").lower()
+
+    if side_to_move not in COLOR_MAP:
+        return None, f"Invalid side_to_move: {side_to_move}"
+
+    # Validate pieces
+    seen_squares: dict[str, dict] = {}
+    kings = {"white": 0, "black": 0}
+    pawns = {"white": 0, "black": 0}
+    king_squares: dict[str, int] = {}
+
+    for piece in pieces:
+        color = piece.get("color", "").lower()
+        ptype = piece.get("type", "").upper()
+        square = piece.get("square", "").lower()
+
+        if color not in COLOR_MAP:
+            return None, f"Invalid color: {color}"
+        if ptype not in PIECE_MAP:
+            return None, f"Invalid piece type: {ptype}"
+        if len(square) != 2 or square[0] not in "abcdefgh" or square[1] not in "12345678":
+            return None, f"Invalid square: {square}"
+
+        sq_index = chess.parse_square(square)
+
+        # Duplicate square — keep the last one (auto-fix)
+        if square in seen_squares:
+            pass  # will be overwritten
+        seen_squares[square] = piece
+
+        if ptype == "K":
+            kings[color] += 1
+            king_squares[color] = sq_index
+        if ptype == "P":
+            pawns[color] += 1
+            rank = int(square[1])
+            if rank == 1 or rank == 8:
+                return None, f"Pawn on invalid rank: {square}"
+
+    # Must have exactly one king per side
+    for c in ("white", "black"):
+        if kings[c] != 1:
+            return None, f"{c} must have exactly 1 king (found {kings[c]})"
+
+    # Kings cannot be adjacent
+    wk = king_squares.get("white")
+    bk = king_squares.get("black")
+    if wk is not None and bk is not None:
+        if chess.square_distance(wk, bk) <= 1:
+            return None, "Kings cannot be adjacent"
+
+    # Max 8 pawns per side
+    for c in ("white", "black"):
+        if pawns[c] > 8:
+            return None, f"{c} has too many pawns ({pawns[c]})"
+
+    # Build the board
+    board = chess.Board.empty()
+    board.turn = COLOR_MAP[side_to_move]
+
+    for square, piece in seen_squares.items():
+        color = COLOR_MAP[piece["color"].lower()]
+        ptype = PIECE_MAP[piece["type"].upper()]
+        sq_index = chess.parse_square(square)
+        board.set_piece_at(sq_index, chess.Piece(ptype, color))
+
+    # Check if the side NOT to move is in check (illegal)
+    board.turn = not board.turn  # temporarily switch
+    if board.is_check():
+        board.turn = not board.turn
+        return None, "The side not to move is in check (illegal position)"
+    board.turn = not board.turn
+
+    return board.fen(), None
 
 
 async def search(query: str) -> list[PositionResult]:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import './App.css'
 
 const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
 const POSITION_MARKER_RE = /\[POSITION:\s*([^\]]+)\]/
+const SETUP_MARKER_RE = /\[SETUP:\s*(\{[\s\S]*?\})\]/
 
 // ── Helpers ──
 
@@ -18,8 +19,8 @@ const MOVE_RE = /(?<![a-zA-Z])([KQRBN][a-h]?[1-8]?x?[a-h][1-8](?:=[QRBN])?[+#]?|
 
 function formatCoachText(raw: string): string {
   let text = raw
-  // Strip position markers from display text
-  text = text.replace(/\[POSITION:\s*[^\]]+\]/g, '').trim()
+  // Strip position/setup markers from display text
+  text = text.replace(/\[POSITION:\s*[^\]]+\]/g, '').replace(/\[SETUP:\s*\{[\s\S]*?\}\]/g, '').trim()
   // Fix tokenizer artifacts
   text = text.replace(/ '/g, "'")
   text = text.replace(/ ([.,;:!?])/g, '$1')
@@ -344,13 +345,14 @@ function App() {
       // Streaming done — finalize message
       if (fullText) {
         const posMatch = fullText.match(POSITION_MARKER_RE)
+        const setupMatch = fullText.match(SETUP_MARKER_RE)
         const assistantMsg: ChatMsg = {
           role: 'assistant',
           text: fullText,
         }
 
         if (posMatch) {
-          // Search for the position
+          // Search curated database
           const query = posMatch[1].trim()
           try {
             const searchRes = await fetch(`/api/positions/search?q=${encodeURIComponent(query)}`, {
@@ -364,7 +366,24 @@ function App() {
                 setBoardFromFen(pos.fen)
               }
             }
-          } catch { /* search failed — no big deal, just don't set the board */ }
+          } catch { /* search failed */ }
+        } else if (setupMatch) {
+          // Validate structured piece list and convert to FEN
+          try {
+            const setupJson = setupMatch[1].replace(/\s+/g, ' ')
+            const setupData = JSON.parse(setupJson)
+            const setupRes = await fetch('/api/positions/setup', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(setupData),
+              signal: controller.signal,
+            })
+            if (setupRes.ok) {
+              const result = await setupRes.json()
+              assistantMsg.positionName = 'Custom position'
+              setBoardFromFen(result.fen)
+            }
+          } catch { /* setup failed */ }
         }
 
         setChatMessages(prev => [...prev, assistantMsg])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,8 +19,12 @@ const MOVE_RE = /(?<![a-zA-Z])([KQRBN][a-h]?[1-8]?x?[a-h][1-8](?:=[QRBN])?[+#]?|
 
 function formatCoachText(raw: string): string {
   let text = raw
-  // Strip position/setup markers from display text
-  text = text.replace(/\[POSITION:\s*[^\]]+\]/g, '').replace(/\[SETUP:\s*\{[\s\S]*?\}\]/g, '').trim()
+  // Strip position/setup markers from display text (including broken/partial ones)
+  text = text.replace(/\[POSITION:\s*[^\]]*\]?/g, '')
+  text = text.replace(/\[SETUP:\s*\{[\s\S]*$/g, '')  // strip from [SETUP: to end if unclosed
+  text = text.replace(/\[SETUP:\s*\{[\s\S]*?\}\]/g, '')  // strip complete ones
+  text = text.replace(/\}\]\s*$/, '')  // strip trailing }]
+  text = text.trim()
   // Fix tokenizer artifacts
   text = text.replace(/ '/g, "'")
   text = text.replace(/ ([.,;:!?])/g, '$1')
@@ -382,8 +386,13 @@ function App() {
               const result = await setupRes.json()
               assistantMsg.positionName = 'Custom position'
               setBoardFromFen(result.fen)
+            } else {
+              const err = await setupRes.json().catch(() => null)
+              console.warn('SETUP validation failed:', err?.error)
             }
-          } catch { /* setup failed */ }
+          } catch (e) {
+            console.warn('SETUP parse failed:', e)
+          }
         }
 
         setChatMessages(prev => [...prev, assistantMsg])


### PR DESCRIPTION
## Summary
LLMs cannot reliably generate FEN strings, but they can list pieces on squares. This adds a structured piece-list format as a fallback for custom positions not in the curated database.

## How it works
1. Coach outputs `[SETUP: {"side_to_move": "white", "pieces": [...]}]`
2. Frontend sends JSON to `/positions/setup`
3. Backend validates (kings, pawns, adjacency, legality) and converts to FEN
4. Board updates if valid, error silently ignored if invalid

## Validation catches
- Missing/extra kings
- Adjacent kings
- Pawns on ranks 1/8
- Too many pawns
- Side not-to-move in check
- Duplicate squares (auto-fixed)

## Two position sources now
- `[POSITION: query]` → curated DB search (preferred, guaranteed correct)
- `[SETUP: {...}]` → LLM-generated piece list (fallback, validated)

## Test plan
- [ ] "Show me a position where White has a rook vs bishop" → uses SETUP
- [ ] Valid piece list → board updates with "Custom position"
- [ ] Invalid (missing king) → board doesn't change, no crash
- [ ] Curated positions still work via [POSITION:]
- [ ] Lichess puzzles still work

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)